### PR TITLE
Correct HW ID

### DIFF
--- a/k760_conf.c
+++ b/k760_conf.c
@@ -30,7 +30,7 @@
 
 #define HID_VENDOR_ID_LOGITECH			(__u32)0x046d
 #define HID_DEVICE_ID_K810              (__s16)0xb319
-#define HID_DEVICE_ID_K760              (__s16)0xb316
+#define HID_DEVICE_ID_K760              (__s16)0xb318
 
 const char k810_seq_fkeys_on[]  = {0x10, 0xff, 0x06, 0x15, 0x00, 0x00, 0x00};
 const char k810_seq_fkeys_off[] = {0x10, 0xff, 0x06, 0x15, 0x01, 0x00, 0x00};


### PR DESCRIPTION
```
Name: Logitech K760
Alias: Logitech K760
Class: 0x000540
Icon: input-keyboard
Paired: yes
Trusted: yes
Blocked: no
Connected: yes
LegacyPairing: no
UUID: Service Discovery Serve.. (00001000-0000-1000-8000-00805f9b34fb)
UUID: Human Interface Device... (00001124-0000-1000-8000-00805f9b34fb)
UUID: PnP Information           (00001200-0000-1000-8000-00805f9b34fb)
Modalias: usb:v046DpB318d011B
```
